### PR TITLE
fix: use specific htmlPattern for Paradox venue inference in HTML con…

### DIFF
--- a/src/enrichment/venues.ts
+++ b/src/enrichment/venues.ts
@@ -11,6 +11,12 @@
 export interface VenueRule {
   /** Regex tested against the event title (case-insensitive) */
   titlePattern: RegExp
+  /**
+   * More specific regex for matching this venue in raw HTML content (event pages,
+   * ticket pages). Should be narrower than titlePattern to avoid false positives
+   * from unrelated sidebar content or recommendations on listing pages.
+   */
+  htmlPattern?: RegExp
   location: string
   city: string
   latitude: number
@@ -20,6 +26,13 @@ export interface VenueRule {
 export const VENUE_RULES: VenueRule[] = [
   {
     titlePattern: /paradox/i,
+    /**
+     * paradoxcnc.com is the Paradox Comics & Games website. Matching the domain
+     * is far more specific than matching the word "paradox" alone, which can
+     * appear in unrelated sidebar content, recommendations, or other events
+     * listed on the same page.
+     */
+    htmlPattern: /paradoxcnc\.com/i,
     location: "Paradox Comics & Games, 403 Main Ave N",
     city: "Fargo",
     latitude: 46.8772,


### PR DESCRIPTION
…tent checks

The previous HTML content checks used /paradox/i which matched the word "paradox" anywhere on a page. This caused false positives when non-Paradox events appeared alongside Paradox events in sidebars, recommendations, or other unrelated content on fargounderground.com event pages or third-party ticket pages.

Fixes: the word "paradox" could appear in sidebar/related-events sections on any fargounderground.com event page, causing every no-venue event to be assigned Paradox Comics & Games as its location.

Changes:
- Add optional `htmlPattern` field to VenueRule in venues.ts for more specific HTML content matching (separate from the broader titlePattern)
- Set htmlPattern to /paradoxcnc\.com/i for Paradox — matching the venue's actual website domain is far more precise than the bare word "paradox"
- Extract and use paradoxHtmlPattern in FargoUndergroundFetcher for both the event page and the tickets page HTML checks

Closes #3